### PR TITLE
Add revert failed builds and include previous commit message options …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.444</version>
+    <version>2.23</version>
   </parent>
   <name>Subversion Revert Plugin</name>
   <licenses>
@@ -193,6 +193,16 @@
       <version>1.37</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>mailer</artifactId>
+      <version>1.6</version>
+    </dependency>   
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.9</version>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.0</version>
@@ -210,8 +220,14 @@
       <version>1.7</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.6</version>
+    </dependency>    
   </dependencies>
   <properties>
+    <jenkins.version>1.645</jenkins.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/src/main/java/jenkins/plugins/svn_revert/ChangedRevisions.java
+++ b/src/main/java/jenkins/plugins/svn_revert/ChangedRevisions.java
@@ -4,6 +4,8 @@ import hudson.model.AbstractBuild;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.Entry;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.List;
 
 import com.google.common.collect.Lists;
@@ -24,4 +26,15 @@ class ChangedRevisions {
         }
         return Revisions.create(revisions);
     }
+    
+    String getCommitMessages() {
+        final ChangeLogSet<? extends Entry> cs = build.getChangeSet();
+        final List<String> commitMessages = Lists.newArrayList();
+        for (final Entry entry : cs) {
+            commitMessages.add(entry.getMsg());
+        }
+        return StringUtils.join(commitMessages," ");        
+    }
+    
+    
 }

--- a/src/main/java/jenkins/plugins/svn_revert/CommitCountRule.java
+++ b/src/main/java/jenkins/plugins/svn_revert/CommitCountRule.java
@@ -25,5 +25,10 @@ public class CommitCountRule {
         final ChangeLogSet<? extends Entry> changeSet = build.getChangeSet();
         return changeSet.getItems().length > 1;
     }
+    
+    public boolean singleCommitOnly() {
+        final ChangeLogSet<? extends Entry> changeSet = build.getChangeSet();
+        return changeSet.getItems().length == 1;        
+    }
 
 }

--- a/src/main/java/jenkins/plugins/svn_revert/Messenger.java
+++ b/src/main/java/jenkins/plugins/svn_revert/Messenger.java
@@ -6,15 +6,19 @@ import org.tmatesoft.svn.core.SVNException;
 
 class Messenger {
 
+
+    static final String UNSTABLE = "UNSTABLE";
     static final String BUILD_STATUS_NOT_UNSTABLE =
             "Will not revert since build status is not UNSTABLE.";
+    static final String BUILD_STATUS_SUCCESS =
+            "Will not revert since build status is SUCCESS";            
     static final String PREVIOUS_BUILD_STATUS_NOT_SUCCESS =
             "Will not revert since previous build status is not SUCCESS.";
     static final String NOT_SUBVERSION_SCM =
             "The Subversion Revert Plugin can only be used with Subversion SCM.";
     static final String NO_SVN_AUTH_PROVIDER = "No Subversion credentials available.";
     static final String REVERTED_CHANGES =
-            "Reverted changes between %d:%d in %s since build became UNSTABLE.\n";
+            "Reverted changes between %d:%d in %s since build became %s.\n";
     static final String NO_CHANGES =
             "Will not revert since there are no changes in current build.";
     static final String FILES_TO_REVERT_OUT_OF_DATE =
@@ -35,6 +39,10 @@ class Messenger {
         this.logger = logger;
     }
 
+    void informBuildStatusSuccess() {
+        logger.println(BUILD_STATUS_SUCCESS);
+    }    
+    
     void informBuildStatusNotUnstable() {
         logger.println(BUILD_STATUS_NOT_UNSTABLE);
     }
@@ -52,7 +60,11 @@ class Messenger {
     }
 
     void informReverted(final Revisions revisions, final String repository) {
-        logger.format(REVERTED_CHANGES, revisions.getBefore(), revisions.getLast(), repository);
+        informReverted(revisions, repository, UNSTABLE);
+    }
+    
+    void informReverted(final Revisions revisions, final String repository, final String status) {
+        logger.format(REVERTED_CHANGES, revisions.getBefore(), revisions.getLast(), repository, status);
     }
 
     void informNoChanges() {

--- a/src/main/java/jenkins/plugins/svn_revert/RevertMailSender.java
+++ b/src/main/java/jenkins/plugins/svn_revert/RevertMailSender.java
@@ -8,6 +8,8 @@ import hudson.tasks.Mailer;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
+import java.io.UnsupportedEncodingException;
+
 class RevertMailSender extends MailSender {
 
     private final RevertMailFormatter formatter;
@@ -21,7 +23,7 @@ class RevertMailSender extends MailSender {
 
     @Override
     protected MimeMessage getMail(final AbstractBuild<?, ?> build, final BuildListener listener)
-            throws MessagingException, InterruptedException {
+            throws MessagingException, InterruptedException, UnsupportedEncodingException {
         final MimeMessage mail = super.getMail(build, listener);
         return formatter.format(mail, build, Mailer.descriptor().getUrl());
     }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugin automatically performs Subversion reverting when the build status changes to unstable or failed.
 </div>

--- a/src/main/resources/jenkins/plugins/svn_revert/JenkinsGlue/global.jelly
+++ b/src/main/resources/jenkins/plugins/svn_revert/JenkinsGlue/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/test/java/jenkins/plugins/svn_revert/CommitCountRuleTest.java
+++ b/src/test/java/jenkins/plugins/svn_revert/CommitCountRuleTest.java
@@ -33,7 +33,9 @@ public class CommitCountRuleTest extends AbstractMockitoTestCase {
     public void setUp() throws Exception {
         changeList = Lists.newLinkedList();
         changeList.add(change);
-        when(build.getChangeSet()).thenReturn(new FakeChangeLogSet(build, changeList));
+        FakeChangeLogSet changeLogSet = new FakeChangeLogSet(null, changeList);
+        when(build.getChangeSet()).thenReturn(changeLogSet);
+        //when(build.getChangeSet()).thenReturn(new FakeChangeLogSet(build, changeList));
         givenWillNotRevertMultipleCommits();
     }
 

--- a/src/test/java/jenkins/plugins/svn_revert/MessengerTest.java
+++ b/src/test/java/jenkins/plugins/svn_revert/MessengerTest.java
@@ -59,13 +59,19 @@ public class MessengerTest extends AbstractMockitoTestCase {
     @Test
     public void logsWhenReverted() throws Exception {
         messenger.informReverted(Revisions.create(2, 2), "repo");
-        verify(logger).format(Messenger.REVERTED_CHANGES, 1, 2, "repo");
+        verify(logger).format(Messenger.REVERTED_CHANGES, 1, 2, "repo","UNSTABLE");
     }
 
     @Test
+    public void logsWhenRevertedFailure() throws Exception {
+        messenger.informReverted(Revisions.create(2, 2), "repo","FAILURE");
+        verify(logger).format(Messenger.REVERTED_CHANGES, 1, 2, "repo","FAILURE");
+    }
+    
+    @Test
     public void logsWhenRevertedOnMultipleRevisions() throws Exception {
-        messenger.informReverted(Revisions.create(2, 4), "repo");
-        verify(logger).format(Messenger.REVERTED_CHANGES, 1, 4, "repo");
+        messenger.informReverted(Revisions.create(2, 4), "repo","UNSTABLE");
+        verify(logger).format(Messenger.REVERTED_CHANGES, 1, 4, "repo","UNSTABLE");
     }
 
     @Test


### PR DESCRIPTION
I added to checkboxes to the build-job config for this plugin so the options can be configured on a per job basis.
1 of the options allows reverts on failed builds.  Reverting on un-stable builds wouldn't work for us.
The 2nd option includes the previous commit message with the revert message. This is necessary for us for auto flagging, pre-commit hooks etc. 